### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/modules/tamandua-aws/pom.xml
+++ b/modules/tamandua-aws/pom.xml
@@ -89,7 +89,7 @@
   	<dependency>
   		<groupId>commons-collections</groupId>
   		<artifactId>commons-collections</artifactId>
-  		<version>3.2.1</version>
+  		<version>3.2.2</version>
   		<type>jar</type>
   		<scope>compile</scope>
   	</dependency>

--- a/modules/tamandua-compressor/pom.xml
+++ b/modules/tamandua-compressor/pom.xml
@@ -89,7 +89,7 @@
   	<dependency>
   		<groupId>commons-collections</groupId>
   		<artifactId>commons-collections</artifactId>
-  		<version>3.2.1</version>
+  		<version>3.2.2</version>
   		<type>jar</type>
   		<scope>compile</scope>
   	</dependency>

--- a/modules/tamandua-crawler/pom.xml
+++ b/modules/tamandua-crawler/pom.xml
@@ -96,7 +96,7 @@
   	<dependency>
   		<groupId>commons-collections</groupId>
   		<artifactId>commons-collections</artifactId>
-  		<version>3.2.1</version>
+  		<version>3.2.2</version>
   		<type>jar</type>
   		<scope>compile</scope>
   	</dependency>

--- a/modules/tamandua-generator/pom.xml
+++ b/modules/tamandua-generator/pom.xml
@@ -109,7 +109,7 @@
   	<dependency>
   		<groupId>commons-collections</groupId>
   		<artifactId>commons-collections</artifactId>
-  		<version>3.2.1</version>
+  		<version>3.2.2</version>
   		<type>jar</type>
   		<scope>compile</scope>
   	</dependency>

--- a/modules/tamandua-images/pom.xml
+++ b/modules/tamandua-images/pom.xml
@@ -81,7 +81,7 @@
   	<dependency>
   		<groupId>commons-collections</groupId>
   		<artifactId>commons-collections</artifactId>
-  		<version>3.2.1</version>
+  		<version>3.2.2</version>
   		<type>jar</type>
   		<scope>compile</scope>
   	</dependency>

--- a/modules/tamandua-indexer/pom.xml
+++ b/modules/tamandua-indexer/pom.xml
@@ -74,7 +74,7 @@
   	<dependency>
   		<groupId>commons-collections</groupId>
   		<artifactId>commons-collections</artifactId>
-  		<version>3.2.1</version>
+  		<version>3.2.2</version>
   		<type>jar</type>
   		<scope>compile</scope>
   	</dependency>

--- a/modules/tamandua-redirect/.settings/org.eclipse.wst.common.component
+++ b/modules/tamandua-redirect/.settings/org.eclipse.wst.common.component
@@ -28,7 +28,7 @@
     <dependent-module archiveName="commons-codec-1.4.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/var/M2_REPO/commons-codec/commons-codec/1.4/commons-codec-1.4.jar">
       <dependency-type>uses</dependency-type>
     </dependent-module>
-    <dependent-module archiveName="commons-collections-3.2.1.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/var/M2_REPO/commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.jar">
+    <dependent-module archiveName="commons-collections-3.2.2.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/var/M2_REPO/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar">
       <dependency-type>uses</dependency-type>
     </dependent-module>
     <dependent-module archiveName="commons-configuration-1.6.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/var/M2_REPO/commons-configuration/commons-configuration/1.6/commons-configuration-1.6.jar">

--- a/modules/tamandua-searcher-ws/.settings/org.eclipse.wst.common.component
+++ b/modules/tamandua-searcher-ws/.settings/org.eclipse.wst.common.component
@@ -13,7 +13,7 @@
     <dependent-module archiveName="commons-codec-1.2.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/var/M2_REPO/commons-codec/commons-codec/1.2/commons-codec-1.2.jar">
       <dependency-type>uses</dependency-type>
     </dependent-module>
-    <dependent-module archiveName="commons-collections-3.2.1.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/var/M2_REPO/commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.jar">
+    <dependent-module archiveName="commons-collections-3.2.2.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/var/M2_REPO/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar">
       <dependency-type>uses</dependency-type>
     </dependent-module>
     <dependent-module archiveName="commons-fileupload-1.2.1.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/var/M2_REPO/commons-fileupload/commons-fileupload/1.2.1/commons-fileupload-1.2.1.jar">

--- a/modules/tamandua-sitemap/pom.xml
+++ b/modules/tamandua-sitemap/pom.xml
@@ -74,7 +74,7 @@
   	<dependency>
   		<groupId>commons-collections</groupId>
   		<artifactId>commons-collections</artifactId>
-  		<version>3.2.1</version>
+  		<version>3.2.2</version>
   		<type>jar</type>
   		<scope>compile</scope>
   	</dependency>

--- a/modules/tamandua-twitter-ws/pom.xml
+++ b/modules/tamandua-twitter-ws/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
         <type>jar</type>
         <scope>compile</scope>
     </dependency>

--- a/modules/tamandua-web/.settings/org.eclipse.wst.common.component
+++ b/modules/tamandua-web/.settings/org.eclipse.wst.common.component
@@ -34,7 +34,7 @@
     <dependent-module archiveName="commons-codec-1.2.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/var/M2_REPO/commons-codec/commons-codec/1.2/commons-codec-1.2.jar">
       <dependency-type>uses</dependency-type>
     </dependent-module>
-    <dependent-module archiveName="commons-collections-3.2.1.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/var/M2_REPO/commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.jar">
+    <dependent-module archiveName="commons-collections-3.2.2.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/var/M2_REPO/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar">
       <dependency-type>uses</dependency-type>
     </dependent-module>
     <dependent-module archiveName="commons-digester-1.8.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/var/M2_REPO/commons-digester/commons-digester/1.8/commons-digester-1.8.jar">

--- a/modules/tamandua-ws/.settings/org.eclipse.wst.common.component
+++ b/modules/tamandua-ws/.settings/org.eclipse.wst.common.component
@@ -46,7 +46,7 @@
     <dependent-module archiveName="commons-codec-1.4.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/var/M2_REPO/commons-codec/commons-codec/1.4/commons-codec-1.4.jar">
       <dependency-type>uses</dependency-type>
     </dependent-module>
-    <dependent-module archiveName="commons-collections-3.2.1.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/var/M2_REPO/commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.jar">
+    <dependent-module archiveName="commons-collections-3.2.2.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/var/M2_REPO/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar">
       <dependency-type>uses</dependency-type>
     </dependent-module>
     <dependent-module archiveName="commons-configuration-1.6.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/var/M2_REPO/commons-configuration/commons-configuration/1.6/commons-configuration-1.6.jar">


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
